### PR TITLE
Remove redundant hooks key from plugin.json

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,6 +9,5 @@
   "homepage": "https://github.com/douglance/devsql",
   "repository": "https://github.com/douglance/devsql",
   "license": "MIT",
-  "keywords": ["sql", "claude-code", "history", "analytics", "productivity"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["sql", "claude-code", "history", "analytics", "productivity"]
 }


### PR DESCRIPTION
## Summary

Removes the `"hooks": "./hooks/hooks.json"` line from `plugin/.claude-plugin/plugin.json`.

## The bug

Claude Code auto-loads `./hooks/hooks.json` from any plugin that contains it. When the manifest also declares `"hooks": "./hooks/hooks.json"`, the loader tries to register the same file twice and fails on startup with:

```
✘ Plugin errors
└ devsql@devsql [devsql]: Hook load failed: Duplicate hooks file detected:
  ./hooks/hooks.json resolves to already-loaded file
  /Users/.../plugins/cache/devsql/devsql/0.2.2/hooks/hooks.json.
  The standard hooks/hooks.json is loaded automatically, so manifest.hooks
  should only reference additional hook files.
```

Every user who installs `devsql` sees this error in their Claude Code session.

## The fix

The `hooks` manifest key is for *additional* hook files beyond the default. Since `devsql` only uses the default `hooks/hooks.json`, the key isn't needed — removing it lets the auto-loader do its job cleanly.

## Test plan

- [ ] Install this branch as a local plugin in Claude Code and confirm no startup error
- [ ] Verify the `devsql:query` slash command and hooks still load correctly